### PR TITLE
[POC] New spacers using custom properties

### DIFF
--- a/packages/clay-css/src/scss/utilities-current.scss
+++ b/packages/clay-css/src/scss/utilities-current.scss
@@ -1,0 +1,92 @@
+@import 'functions/_global-functions';
+@import 'atlas/_variables';
+@import '_variables';
+@import '_mixins';
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+	@include media-breakpoint-up($breakpoint) {
+		$infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+		@each $prop, $abbrev in (margin: m, padding: p) {
+			@each $size, $length in $spacers {
+				.#{$abbrev}#{$infix}-#{$size} {
+					#{$prop}: $length !important;
+				}
+
+				.#{$abbrev}t#{$infix}-#{$size},
+				.#{$abbrev}y#{$infix}-#{$size} {
+					#{$prop}-top: $length !important;
+				}
+
+				.#{$abbrev}r#{$infix}-#{$size},
+				.#{$abbrev}x#{$infix}-#{$size} {
+					#{$prop}-right: $length !important;
+				}
+
+				.#{$abbrev}b#{$infix}-#{$size},
+				.#{$abbrev}y#{$infix}-#{$size} {
+					#{$prop}-bottom: $length !important;
+				}
+
+				.#{$abbrev}l#{$infix}-#{$size},
+				.#{$abbrev}x#{$infix}-#{$size} {
+					#{$prop}-left: $length !important;
+				}
+			}
+		}
+
+		// Negative margins (e.g., where `.mb-n1` is negative version of `.mb-1`)
+
+		@each $size, $length in $spacers {
+			@if $size != 0 {
+				.m#{$infix}-n#{$size} {
+					margin: -$length !important;
+				}
+
+				.mt#{$infix}-n#{$size},
+				.my#{$infix}-n#{$size} {
+					margin-top: -$length !important;
+				}
+
+				.mr#{$infix}-n#{$size},
+				.mx#{$infix}-n#{$size} {
+					margin-right: -$length !important;
+				}
+
+				.mb#{$infix}-n#{$size},
+				.my#{$infix}-n#{$size} {
+					margin-bottom: -$length !important;
+				}
+
+				.ml#{$infix}-n#{$size},
+				.mx#{$infix}-n#{$size} {
+					margin-left: -$length !important;
+				}
+			}
+		}
+
+		.m#{$infix}-auto {
+			margin: auto !important;
+		}
+
+		.mt#{$infix}-auto,
+		.my#{$infix}-auto {
+			margin-top: auto !important;
+		}
+
+		.mr#{$infix}-auto,
+		.mx#{$infix}-auto {
+			margin-right: auto !important;
+		}
+
+		.mb#{$infix}-auto,
+		.my#{$infix}-auto {
+			margin-bottom: auto !important;
+		}
+
+		.ml#{$infix}-auto,
+		.mx#{$infix}-auto {
+			margin-left: auto !important;
+		}
+	}
+}

--- a/packages/clay-css/src/scss/utilities-proposal.scss
+++ b/packages/clay-css/src/scss/utilities-proposal.scss
@@ -1,0 +1,67 @@
+@import 'functions/_global-functions';
+@import 'atlas/_variables';
+@import '_variables';
+@import '_mixins';
+
+[class*='-n'] {
+	--spacer-sign: -1;
+}
+
+[class*='-auto'] {
+	--spacer: var(--spacer-breakpoint, auto);
+}
+
+@each $size, $length in $spacers {
+	[class*='#{$size}'] {
+		--spacer-size: calc(#{$length} * var(--spacer-sign, 1));
+		--spacer: var(--spacer-breakpoint, var(--spacer-size));
+	}
+}
+
+@each $prop, $abbrev in (margin: m, padding: p) {
+	[class*='#{$abbrev}-'] {
+		#{$prop}: var(--spacer) !important;
+	}
+
+	[class*='#{$abbrev}t-'],
+	[class*='#{$abbrev}y-'] {
+		#{$prop}-top: var(--spacer) !important;
+	}
+
+	[class*='#{$abbrev}r-'],
+	[class*='#{$abbrev}x-'] {
+		#{$prop}-right: var(--spacer) !important;
+	}
+
+	[class*='#{$abbrev}b-'],
+	[class*='#{$abbrev}y-'] {
+		#{$prop}-bottom: var(--spacer) !important;
+	}
+
+	[class*='#{$abbrev}l-'],
+	[class*='#{$abbrev}x-'] {
+		#{$prop}-left: var(--spacer) !important;
+	}
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+	[class*='#{$breakpoint}'] {
+		--spacer-breakpoint: 'initial';
+	}
+}
+
+@each $breakpoint in map-keys($grid-breakpoints) {
+	@include media-breakpoint-up($breakpoint) {
+		$infix: breakpoint-infix($breakpoint, $grid-breakpoints);
+
+		@if $infix != '' {
+			[class*='#{$infix}'] {
+				--spacer-breakpoint: var(--spacer-size);
+			}
+
+			[class*='#{$infix}-auto'] {
+				--spacer-breakpoint: auto;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR tries to define a new spacer utility system to reduce the weight of the CSS

It definitely works

![image](https://user-images.githubusercontent.com/46778114/121549876-871b5380-ca0e-11eb-8f56-0803e50a5358.png)


[POC Demo](https://codepen.io/eduardoallegrini/pen/ExWeQdj)

I'm still working on a few issues
- the combination of multiple breakpoints (e.g. `.mt-md-3 .mt-lg-5`) doesn't work because the md takes the number from the lg creating a `.mt-md-5`
- some classes like `mt-sm-3` define all the margins because of `m-`